### PR TITLE
Fix nav button cleanup

### DIFF
--- a/content.js
+++ b/content.js
@@ -233,9 +233,9 @@ function startHeartbeat() {
 // Initialize floating buttons
 function initializeFloatingButtons() {
 	try {
-		// Remove any existing buttons from nav (cleanup)
-		const existingNavButtons = document.querySelectorAll('#cgpt-saver-btn, #cgpt-nav-btn');
-		existingNavButtons.forEach(btn => btn.remove());
+               // Remove old floating buttons to prevent duplicates
+               const existingNavButtons = document.querySelectorAll('#cgpt-save-btn, #cgpt-nav-btn');
+               existingNavButtons.forEach(btn => btn.remove());
 		
 		// Create floating container
 		createFloatingButtonContainer();


### PR DESCRIPTION
## Summary
- clarify comment when removing old floating buttons
- remove existing `#cgpt-save-btn` and `#cgpt-nav-btn` to avoid duplicates

## Testing
- `node -c content.js`


------
https://chatgpt.com/codex/tasks/task_e_68637b3b1400832984eb4621d64fc238