### PR TITLE
Add Jest setup and navigation panel test

### DIFF
--- a/content.js
+++ b/content.js
@@ -311,7 +311,15 @@ document.addEventListener('visibilitychange', () => {
 
 // Cleanup on page unload
 window.addEventListener('beforeunload', () => {
-	if (heartbeatInterval) {
-		clearInterval(heartbeatInterval);
-	}
+        if (heartbeatInterval) {
+                clearInterval(heartbeatInterval);
+        }
 });
+
+// Export functions for testing environments
+if (typeof module !== 'undefined' && module.exports) {
+        module.exports = {
+                updateNavigationPanel,
+                createNavigationPanel
+        };
+}

--- a/content.test.js
+++ b/content.test.js
@@ -1,0 +1,61 @@
+const { JSDOM } = require('jsdom');
+
+// Provide stub for chrome.storage used in content.js
+beforeAll(() => {
+  global.chrome = {
+    storage: {
+      local: {
+        get: jest.fn().mockResolvedValue({}),
+        set: jest.fn().mockResolvedValue(undefined)
+      },
+      sync: {
+        get: jest.fn().mockResolvedValue({}),
+        set: jest.fn().mockResolvedValue(undefined)
+      }
+    }
+  };
+});
+
+describe('updateNavigationPanel', () => {
+  let window, document, updateNavigationPanel, createNavigationPanel;
+
+  beforeEach(async () => {
+    const dom = new JSDOM(`<!DOCTYPE html><body></body>`);
+    window = dom.window;
+    document = window.document;
+    global.window = window;
+    global.document = document;
+
+    ({ updateNavigationPanel, createNavigationPanel } = require('./content.js'));
+
+    // create navigation panel element
+    createNavigationPanel();
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    delete global.window;
+    delete global.document;
+  });
+
+  test('populates buttons for detected messages', () => {
+    // create dummy messages
+    const msg1 = document.createElement('div');
+    msg1.setAttribute('data-message-author-role', 'user');
+    msg1.textContent = 'Hello world';
+
+    const msg2 = document.createElement('div');
+    msg2.setAttribute('data-message-author-role', 'assistant');
+    msg2.textContent = 'Hello back';
+
+    document.body.appendChild(msg1);
+    document.body.appendChild(msg2);
+
+    updateNavigationPanel();
+
+    const buttons = document.querySelectorAll('#cgpt-nav-panel .cgpt-message-btn');
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0].textContent).toContain('Hello world');
+    expect(buttons[1].textContent).toContain('Hello back');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "PromptPin",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^22.1.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add `package.json` with Jest and jsdom
- export functions from `content.js` for testing
- test that navigation panel populates detected messages

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686383bd32648329b0bbc18f6fe24288