### PR TITLE
Add keyboard shortcuts for save and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ A Chrome extension that enhances your ChatGPT experience by adding bookmarking a
 ### 3. Search Saved Chats
 - Quickly filter your saved conversations by title or URL using the popup search box
 
+### 4. Keyboard Shortcuts
+- **Alt+S** &ndash; Save the current conversation
+- **Alt+M** &ndash; Show or hide the message navigator
+
 ## Installation
 
 1. Clone this repository:
@@ -38,6 +42,7 @@ git clone https://github.com/abhi3315/PromptPin
 1. Click the "⭐ Save" button in the ChatGPT header
 2. The button will change to "✅ Saved" when successful
 3. Access saved conversations through the extension popup
+4. Or press **Alt+S** (Option+S on Mac) to save instantly
 
 ### Using Message Navigation
 1. Click the "📋 Messages" button in the ChatGPT header
@@ -45,3 +50,4 @@ git clone https://github.com/abhi3315/PromptPin
 3. Browse through the list of messages
 4. Click any message to jump to it in the conversation
 5. Click the button again to hide the panel
+6. Or press **Alt+M** (Option+M on Mac) to toggle the panel

--- a/content.js
+++ b/content.js
@@ -203,7 +203,37 @@ function updateNavigationPanel() {
 		messageList.appendChild(button);
 	});
 	
-	panel.appendChild(messageList);
+        panel.appendChild(messageList);
+}
+
+// Initialize global keyboard shortcuts
+let shortcutsInitialized = false;
+function setupKeyboardShortcuts() {
+        if (shortcutsInitialized) return;
+        shortcutsInitialized = true;
+
+        document.addEventListener('keydown', (e) => {
+                if (!e.altKey || e.shiftKey || e.ctrlKey || e.metaKey) return;
+
+                const active = document.activeElement;
+                if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable)) {
+                        return;
+                }
+
+                if (e.key === 's' || e.key === 'S') {
+                        const saveBtn = document.getElementById('cgpt-save-btn');
+                        if (saveBtn) {
+                                e.preventDefault();
+                                saveBtn.click();
+                        }
+                } else if (e.key === 'm' || e.key === 'M') {
+                        const navBtn = document.getElementById('cgpt-nav-btn');
+                        if (navBtn) {
+                                e.preventDefault();
+                                navBtn.click();
+                        }
+                }
+        });
 }
 
 // Check if buttons exist and recreate if needed
@@ -301,6 +331,9 @@ if (document.readyState === 'loading') {
 
 // Setup the mutation observer
 setupMutationObserver();
+
+// Enable keyboard shortcuts
+setupKeyboardShortcuts();
 
 // Handle page visibility changes
 document.addEventListener('visibilitychange', () => {


### PR DESCRIPTION
## Summary
- add Alt+S to save chats
- add Alt+M to toggle the message navigator
- document the new shortcuts

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68639c7f50d88329be80b73781d62d61