### PR TITLE
Fix popup list refresh after deletion

### DIFF
--- a/popup/popup.js
+++ b/popup/popup.js
@@ -25,7 +25,17 @@ document.addEventListener("DOMContentLoaded", async () => {
                                 await chrome.storage.sync.set({ saved: filtered });
                                 const index = all.findIndex((s) => s.url === item.url);
                                 if (index !== -1) all.splice(index, 1);
-                                render(filtered);
+
+                                const q = searchEl.value.toLowerCase();
+                                const itemsToRender = q
+                                        ? all.filter(
+                                                (itm) =>
+                                                        (itm.title && itm.title.toLowerCase().includes(q)) ||
+                                                        itm.url.toLowerCase().includes(q)
+                                        )
+                                        : filtered;
+
+                                render(itemsToRender);
                         };
                         listEl.appendChild(li);
                 });


### PR DESCRIPTION
## Summary
- ensure list updates when deleting an item even if a search is active

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68639cf5c63c8329996276c56c202ce5