### PR TITLE
Add tagging support for saved chats

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ A Chrome extension that enhances your ChatGPT experience by adding bookmarking a
 ### 3. Search Saved Chats
 - Quickly filter your saved conversations by title or URL using the popup search box
 
-### 4. Keyboard Shortcuts
+### 4. Tag Saved Chats
+- Assign custom tags to your saved conversations directly from the popup
+- Filter chats by their tags for faster organization
+
+### 5. Keyboard Shortcuts
 - **Alt+S** &ndash; Save the current conversation
 - **Alt+M** &ndash; Show or hide the message navigator
 

--- a/content.js
+++ b/content.js
@@ -125,7 +125,7 @@ function setupSaveButton(btn) {
 				}, 2000);
 				return;
 			}
-			saved.push({ title, url, date: Date.now() });
+                        saved.push({ title, url, date: Date.now(), tags: [] });
 			await chrome.storage.sync.set({ saved });
 			btn.textContent = "✅ Saved";
 			setTimeout(() => {

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -11,13 +11,14 @@
     <h1>Saved Chats</h1>
     <input type="search" id="search" class="search" placeholder="Search...">
     <ul id="list"></ul>
-	<template id="item-template">
-		<li>
-			<a target="_blank" rel="noopener"></a>
-			<button class="del">🗑️</button>
-		</li>
-	</template>
-	<script src="popup.js"></script>
+        <template id="item-template">
+                <li>
+                        <a target="_blank" rel="noopener"></a>
+                        <input type="text" class="tags" placeholder="Tags" />
+                        <button class="del">🗑️</button>
+                </li>
+        </template>
+        <script src="popup.js"></script>
 </body>
 
 </html>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -18,8 +18,17 @@ document.addEventListener("DOMContentLoaded", async () => {
                 items.forEach((item) => {
                         const li = tpl.cloneNode(true);
                         const link = li.querySelector("a");
+                        const tagsInput = li.querySelector(".tags");
                         link.textContent = item.title || "(untitled)";
                         link.href = item.url;
+                        tagsInput.value = item.tags ? item.tags.join(", ") : "";
+                        tagsInput.addEventListener("change", async () => {
+                                item.tags = tagsInput.value
+                                        .split(",")
+                                        .map((t) => t.trim())
+                                        .filter(Boolean);
+                                await chrome.storage.sync.set({ saved: all });
+                        });
                         li.querySelector(".del").onclick = async () => {
                                 const filtered = all.filter((s) => s.url !== item.url);
                                 await chrome.storage.sync.set({ saved: filtered });
@@ -29,9 +38,10 @@ document.addEventListener("DOMContentLoaded", async () => {
                                 const q = searchEl.value.toLowerCase();
                                 const itemsToRender = q
                                         ? all.filter(
-                                                (itm) =>
-                                                        (itm.title && itm.title.toLowerCase().includes(q)) ||
-                                                        itm.url.toLowerCase().includes(q)
+                                        (itm) =>
+                                                (itm.title && itm.title.toLowerCase().includes(q)) ||
+                                                itm.url.toLowerCase().includes(q) ||
+                                                (itm.tags && itm.tags.some((tag) => tag.toLowerCase().includes(q)))
                                         )
                                         : filtered;
 
@@ -46,7 +56,8 @@ document.addEventListener("DOMContentLoaded", async () => {
                 const filtered = all.filter(
                         (item) =>
                                 (item.title && item.title.toLowerCase().includes(q)) ||
-                                item.url.toLowerCase().includes(q)
+                                item.url.toLowerCase().includes(q) ||
+                                (item.tags && item.tags.some((tag) => tag.toLowerCase().includes(q)))
                 );
                 render(filtered);
         });

--- a/style.css
+++ b/style.css
@@ -198,7 +198,22 @@
         box-sizing: border-box;
 }
 
+.popup input.tags {
+        width: 100%;
+        padding: 4px 8px;
+        margin-top: 6px;
+        border: 1px solid #d1d5db;
+        border-radius: 6px;
+        font-size: 12px;
+        box-sizing: border-box;
+}
+
 .popup input.search:focus {
+        outline: none;
+        border-color: #10b981;
+}
+
+.popup input.tags:focus {
         outline: none;
         border-color: #10b981;
 }
@@ -340,7 +355,17 @@
                 color: #f3f4f6;
         }
 
+        .popup input.tags {
+                background: #374151;
+                border-color: rgba(255, 255, 255, 0.2);
+                color: #f3f4f6;
+        }
+
         .popup input.search:focus {
+                border-color: #10b981;
+        }
+
+        .popup input.tags:focus {
                 border-color: #10b981;
         }
 	


### PR DESCRIPTION
## Summary
- enable tags field when saving chats
- let users edit tags in the popup
- search chats by tags
- document tagging feature

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68639dbe45a88329a567f700c328144c