### PR TITLE
Add tag chips and collection grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,13 @@ A Chrome extension that enhances your ChatGPT experience by adding bookmarking a
 ### 4. Tag Saved Chats
 - Assign custom tags to your saved conversations directly from the popup
 - Filter chats by their tags for faster organization
+- Tags appear as removable chips in the popup for quick editing
 
-### 5. Keyboard Shortcuts
+### 5. Collections (optional)
+- Organize saved chats into named collections
+- The popup groups chats under their collection headings
+
+### 6. Keyboard Shortcuts
 - **Alt+S** &ndash; Save the current conversation
 - **Alt+M** &ndash; Show or hide the message navigator
 

--- a/content.js
+++ b/content.js
@@ -125,7 +125,7 @@ function setupSaveButton(btn) {
 				}, 2000);
 				return;
 			}
-                        saved.push({ title, url, date: Date.now(), tags: [] });
+                        saved.push({ title, url, date: Date.now(), tags: [], collection: "" });
 			await chrome.storage.sync.set({ saved });
 			btn.textContent = "✅ Saved";
 			setTimeout(() => {

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -14,7 +14,8 @@
         <template id="item-template">
                 <li>
                         <a target="_blank" rel="noopener"></a>
-                        <input type="text" class="tags" placeholder="Tags" />
+                        <div class="tags"></div>
+                        <input type="text" class="tag-input" placeholder="New tag" style="display:none" />
                         <button class="del">🗑️</button>
                 </li>
         </template>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,3 +1,19 @@
+function createTagChip(tag, item, all) {
+        const chip = document.createElement("span");
+        chip.className = "tag-chip";
+        chip.textContent = tag;
+        const btn = document.createElement("button");
+        btn.textContent = "×";
+        btn.onclick = async () => {
+                const idx = item.tags.indexOf(tag);
+                if (idx !== -1) item.tags.splice(idx, 1);
+                chip.remove();
+                await chrome.storage.sync.set({ saved: all });
+        };
+        chip.appendChild(btn);
+        return chip;
+}
+
 document.addEventListener("DOMContentLoaded", async () => {
         const listEl = document.getElementById("list");
         const searchEl = document.getElementById("search");
@@ -15,39 +31,72 @@ document.addEventListener("DOMContentLoaded", async () => {
                         return;
                 }
 
-                items.forEach((item) => {
-                        const li = tpl.cloneNode(true);
-                        const link = li.querySelector("a");
-                        const tagsInput = li.querySelector(".tags");
-                        link.textContent = item.title || "(untitled)";
-                        link.href = item.url;
-                        tagsInput.value = item.tags ? item.tags.join(", ") : "";
-                        tagsInput.addEventListener("change", async () => {
-                                item.tags = tagsInput.value
-                                        .split(",")
-                                        .map((t) => t.trim())
-                                        .filter(Boolean);
-                                await chrome.storage.sync.set({ saved: all });
+                const groups = {};
+                items.forEach((it) => {
+                        const col = it.collection || "Unsorted";
+                        if (!groups[col]) groups[col] = [];
+                        groups[col].push(it);
+                });
+
+                Object.entries(groups).forEach(([col, arr]) => {
+                        const header = document.createElement("li");
+                        header.className = "collection-header";
+                        header.textContent = col;
+                        listEl.appendChild(header);
+
+                        arr.forEach((item) => {
+                                const li = tpl.cloneNode(true);
+                                const link = li.querySelector("a");
+                                const tagsEl = li.querySelector(".tags");
+                                const tagInput = li.querySelector(".tag-input");
+                                link.textContent = item.title || "(untitled)";
+                                link.href = item.url;
+
+                                tagsEl.onclick = () => {
+                                        tagInput.style.display = "inline-block";
+                                        tagInput.focus();
+                                };
+
+                                tagInput.addEventListener("keydown", async (e) => {
+                                        if (e.key === "Enter" && tagInput.value.trim()) {
+                                                const t = tagInput.value.trim();
+                                                item.tags = item.tags || [];
+                                                item.tags.push(t);
+                                                tagsEl.appendChild(createTagChip(t, item, all));
+                                                tagInput.value = "";
+                                                tagInput.style.display = "none";
+                                                await chrome.storage.sync.set({ saved: all });
+                                        } else if (e.key === "Escape") {
+                                                tagInput.value = "";
+                                                tagInput.style.display = "none";
+                                        }
+                                });
+
+                                if (item.tags) {
+                                        item.tags.forEach((t) => tagsEl.appendChild(createTagChip(t, item, all)));
+                                }
+
+                                li.querySelector(".del").onclick = async () => {
+                                        const filtered = all.filter((s) => s.url !== item.url);
+                                        await chrome.storage.sync.set({ saved: filtered });
+                                        const index = all.findIndex((s) => s.url === item.url);
+                                        if (index !== -1) all.splice(index, 1);
+
+                                        const q = searchEl.value.toLowerCase();
+                                        const itemsToRender = q
+                                                ? all.filter(
+                                                          (itm) =>
+                                                                  (itm.title && itm.title.toLowerCase().includes(q)) ||
+                                                                  itm.url.toLowerCase().includes(q) ||
+                                                                  (itm.collection && itm.collection.toLowerCase().includes(q)) ||
+                                                                  (itm.tags && itm.tags.some((tag) => tag.toLowerCase().includes(q)))
+                                                  )
+                                                : filtered;
+
+                                        render(itemsToRender);
+                                };
+                                listEl.appendChild(li);
                         });
-                        li.querySelector(".del").onclick = async () => {
-                                const filtered = all.filter((s) => s.url !== item.url);
-                                await chrome.storage.sync.set({ saved: filtered });
-                                const index = all.findIndex((s) => s.url === item.url);
-                                if (index !== -1) all.splice(index, 1);
-
-                                const q = searchEl.value.toLowerCase();
-                                const itemsToRender = q
-                                        ? all.filter(
-                                        (itm) =>
-                                                (itm.title && itm.title.toLowerCase().includes(q)) ||
-                                                itm.url.toLowerCase().includes(q) ||
-                                                (itm.tags && itm.tags.some((tag) => tag.toLowerCase().includes(q)))
-                                        )
-                                        : filtered;
-
-                                render(itemsToRender);
-                        };
-                        listEl.appendChild(li);
                 });
         }
 
@@ -57,6 +106,7 @@ document.addEventListener("DOMContentLoaded", async () => {
                         (item) =>
                                 (item.title && item.title.toLowerCase().includes(q)) ||
                                 item.url.toLowerCase().includes(q) ||
+                                (item.collection && item.collection.toLowerCase().includes(q)) ||
                                 (item.tags && item.tags.some((tag) => tag.toLowerCase().includes(q)))
                 );
                 render(filtered);
@@ -64,3 +114,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
         render(all);
 });
+
+if (typeof module !== "undefined" && module.exports) {
+        module.exports = { createTagChip };
+}

--- a/popup/popup.test.js
+++ b/popup/popup.test.js
@@ -1,0 +1,27 @@
+const { JSDOM } = require('jsdom');
+const { createTagChip } = require('./popup.js');
+
+describe('createTagChip', () => {
+  beforeAll(() => {
+    global.chrome = {
+      storage: {
+        sync: {
+          set: jest.fn().mockResolvedValue(undefined)
+        }
+      }
+    };
+  });
+
+  test('removes tag from item when clicked', async () => {
+    const dom = new JSDOM('<div id="c"></div>');
+    global.document = dom.window.document;
+    const container = dom.window.document.getElementById('c');
+    const item = { tags: ['foo'] };
+    const all = [item];
+    const chip = createTagChip('foo', item, all);
+    container.appendChild(chip);
+    await chip.querySelector('button').onclick();
+    expect(item.tags).toHaveLength(0);
+    expect(container.children.length).toBe(0);
+  });
+});

--- a/style.css
+++ b/style.css
@@ -198,7 +198,7 @@
         box-sizing: border-box;
 }
 
-.popup input.tags {
+.popup input.tag-input {
         width: 100%;
         padding: 4px 8px;
         margin-top: 6px;
@@ -213,7 +213,7 @@
         border-color: #10b981;
 }
 
-.popup input.tags:focus {
+.popup input.tag-input:focus {
         outline: none;
         border-color: #10b981;
 }
@@ -239,8 +239,14 @@
 }
 
 .popup li:hover {
-	border-color: #10b981;
-	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        border-color: #10b981;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.popup .collection-header {
+        font-weight: 600;
+        margin-top: 12px;
+        margin-bottom: 4px;
 }
 
 .popup a {
@@ -256,7 +262,32 @@
 }
 
 .popup a:hover {
-	color: #1d4ed8;
+        color: #1d4ed8;
+}
+
+.popup .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        margin-top: 6px;
+}
+
+.popup .tag-chip {
+        background: #e5e7eb;
+        border-radius: 9999px;
+        padding: 2px 6px;
+        font-size: 12px;
+        display: inline-flex;
+        align-items: center;
+}
+
+.popup .tag-chip button {
+        background: none;
+        border: none;
+        margin-left: 4px;
+        cursor: pointer;
+        font-size: 12px;
+        line-height: 1;
 }
 
 .popup button.del {
@@ -355,7 +386,7 @@
                 color: #f3f4f6;
         }
 
-        .popup input.tags {
+        .popup input.tag-input {
                 background: #374151;
                 border-color: rgba(255, 255, 255, 0.2);
                 color: #f3f4f6;
@@ -365,7 +396,7 @@
                 border-color: #10b981;
         }
 
-        .popup input.tags:focus {
+        .popup input.tag-input:focus {
                 border-color: #10b981;
         }
 	
@@ -382,9 +413,17 @@
 		color: #60a5fa;
 	}
 	
-	.popup a:hover {
-		color: #93c5fd;
-	}
+        .popup a:hover {
+                color: #93c5fd;
+        }
+
+        .popup .tag-chip {
+                background: #4b5563;
+        }
+
+        .popup .collection-header {
+                color: #f3f4f6;
+        }
 	
 	.popup .empty-state {
 		color: #9ca3af;


### PR DESCRIPTION
## Summary
- replace tag input with tag chip container in popup HTML
- implement tag chip functionality and collection grouping in popup script
- save new chats with blank collection field
- style tag chips and collection headers
- document tag chips and collection features
- test tag chip removal logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a2e7e02083298be2c84aecea8a86